### PR TITLE
Lime 834 Updating support link for contact centre one-login

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -11,7 +11,7 @@ govuk:
   skipLink: "Neidio i’r prif gynnwys"
   phaseBanner:
     tag: beta
-    content: 'Mae hwn yn wasanaeth newydd – bydd eich <a class="govuk-link" rel="noopener" target="_blank" href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=passport-cri">adborth (agor mewn tab newydd)</a> yn ein helpu i’w wella.'
+    content: 'Mae hwn yn wasanaeth newydd – bydd eich <a class="govuk-link" rel="noopener" target="_blank" href="https://home.account.gov.uk/contact-gov-uk-one-login">adborth (agor mewn tab newydd)</a> yn ein helpu i’w wella.'
   cookie:
     cookieBanner:
       title: "Cwcis ar GOV.UK One Login"
@@ -40,7 +40,7 @@ govuk:
           text: "Telerau ac amodau"
         - href: "https://signin.account.gov.uk/privacy-notice"
           text: "Hysbysiad preifatrwydd"
-        - href: "https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=passport-cri"
+        - href: "https://home.account.gov.uk/contact-gov-uk-one-login"
           text: "Cymorth"
     contentLicence:
       html: 'Mae’r holl gynnwys ar gael o dan <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Trwydded Llywodraeth Agored v3.0</a>, oni nodir yn wahanol'

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -11,7 +11,7 @@ govuk:
   skipLink: "Neidio i’r prif gynnwys"
   phaseBanner:
     tag: beta
-    content: 'Mae hwn yn wasanaeth newydd – bydd eich <a class="govuk-link" rel="noopener" target="_blank" href="https://signin.account.gov.uk/contact-us">adborth (agor mewn tab newydd)</a> yn ein helpu i’w wella.'
+    content: 'Mae hwn yn wasanaeth newydd – bydd eich <a class="govuk-link" rel="noopener" target="_blank" href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=passport-cri">adborth (agor mewn tab newydd)</a> yn ein helpu i’w wella.'
   cookie:
     cookieBanner:
       title: "Cwcis ar GOV.UK One Login"
@@ -40,7 +40,7 @@ govuk:
           text: "Telerau ac amodau"
         - href: "https://signin.account.gov.uk/privacy-notice"
           text: "Hysbysiad preifatrwydd"
-        - href: "https://signin.account.gov.uk/contact-us"
+        - href: "https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=passport-cri"
           text: "Cymorth"
     contentLicence:
       html: 'Mae’r holl gynnwys ar gael o dan <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Trwydded Llywodraeth Agored v3.0</a>, oni nodir yn wahanol'

--- a/src/locales/cy/pages.errors.yml
+++ b/src/locales/cy/pages.errors.yml
@@ -6,7 +6,7 @@ error:
     - '<h2 class="govuk-heading-m"> Beth allwch chi ei wneud </h2>'
     - "Ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK."
     - '<a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button"> Ewch i hafan GOV.UK </a>'
-    - '<a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=passport-cri" class="govuk-link"> Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd) </a>'
+    - '<a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank"> Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd) </a>'
 pageNotFound:
   title: "Tudalen heb ei darganfod"
   serviceNameRequired: false
@@ -15,7 +15,7 @@ pageNotFound:
     - "Os ydych wedi gludo’r cyfeiriad gwe, edrychwch i weld eich bod wedi copïo’r cyfeiriad cyfan."
     - "Gallwch hefyd fynd yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddi’ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK."
     - '<a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Ewch i hafan GOV.UK</a>'
-    - '<a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=passport-cri" class="govuk-link">Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)</a>'
+    - '<a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank">Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)</a>'
 sessionEnded:
   title: "Sesiwn wedi dod i ben"
   serviceNameRequired: false

--- a/src/locales/cy/pages.errors.yml
+++ b/src/locales/cy/pages.errors.yml
@@ -6,7 +6,7 @@ error:
     - '<h2 class="govuk-heading-m"> Beth allwch chi ei wneud </h2>'
     - "Ewch yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio’ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK."
     - '<a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button"> Ewch i hafan GOV.UK </a>'
-    - '<a href="https://signin.account.gov.uk/contact-us" class="govuk-link"> Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd) </a>'
+    - '<a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=passport-cri" class="govuk-link"> Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd) </a>'
 pageNotFound:
   title: "Tudalen heb ei darganfod"
   serviceNameRequired: false
@@ -15,7 +15,7 @@ pageNotFound:
     - "Os ydych wedi gludo’r cyfeiriad gwe, edrychwch i weld eich bod wedi copïo’r cyfeiriad cyfan."
     - "Gallwch hefyd fynd yn ôl i’r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddi’ch peiriant chwilio neu ddod o hyd iddo o hafan GOV.UK."
     - '<a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Ewch i hafan GOV.UK</a>'
-    - '<a href="https://signin.account.gov.uk/contact-us" class="govuk-link">Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)</a>'
+    - '<a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=passport-cri" class="govuk-link">Cysylltu â thîm cyfrif GOV.UK (agor mewn tab newydd)</a>'
 sessionEnded:
   title: "Sesiwn wedi dod i ben"
   serviceNameRequired: false

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -11,7 +11,7 @@ govuk:
   skipLink: Skip to main content
   phaseBanner:
     tag: beta
-    content: 'This is a new service – your <a class="govuk-link" rel="noopener" target="_blank" href="https://signin.account.gov.uk/contact-us">feedback (opens in new tab)</a>  will help us to improve it.'
+    content: 'This is a new service – your <a class="govuk-link" rel="noopener" target="_blank" href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=passport-cri">feedback (opens in new tab)</a>  will help us to improve it.'
   cookie:
     cookieBanner:
       title: Cookies on GOV.UK One Login
@@ -40,7 +40,7 @@ govuk:
           text: "Terms and conditions"
         - href: "https://signin.account.gov.uk/privacy-notice"
           text: "Privacy notice"
-        - href: "https://signin.account.gov.uk/contact-us"
+        - href: "https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=passport-cri"
           text: "Support"
     contentLicence:
       #html: "Unchanged from Default"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -11,7 +11,7 @@ govuk:
   skipLink: Skip to main content
   phaseBanner:
     tag: beta
-    content: 'This is a new service – your <a class="govuk-link" rel="noopener" target="_blank" href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=passport-cri">feedback (opens in new tab)</a>  will help us to improve it.'
+    content: 'This is a new service – your <a class="govuk-link" rel="noopener" target="_blank" href="https://home.account.gov.uk/contact-gov-uk-one-login">feedback (opens in new tab)</a>  will help us to improve it.'
   cookie:
     cookieBanner:
       title: Cookies on GOV.UK One Login
@@ -40,7 +40,7 @@ govuk:
           text: "Terms and conditions"
         - href: "https://signin.account.gov.uk/privacy-notice"
           text: "Privacy notice"
-        - href: "https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=passport-cri"
+        - href: "https://home.account.gov.uk/contact-gov-uk-one-login"
           text: "Support"
     contentLicence:
       #html: "Unchanged from Default"

--- a/src/locales/en/pages.errors.yml
+++ b/src/locales/en/pages.errors.yml
@@ -6,7 +6,7 @@ error:
     - <h2 class="govuk-heading-m"> What you can do </h2>
     - Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button"> Go the GOV.UK homepage </a>
-    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=passport-cri" class="govuk-link"> Contact the GOV.UK account team (opens in a new tab) </a>
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank"> Contact the GOV.UK account team (opens in a new tab) </a>
 
 pageNotFound:
   title: Page not found
@@ -16,7 +16,7 @@ pageNotFound:
     - If you pasted the web address, check you copied the entire address.
     - You can also go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Go to the GOV.UK homepage</a>
-    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=passport-cri" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login" class="govuk-link" target="_blank">Contact the GOV.UK account team (opens in a new tab)</a>
 
 sessionEnded:
   title: Session expired

--- a/src/locales/en/pages.errors.yml
+++ b/src/locales/en/pages.errors.yml
@@ -6,7 +6,7 @@ error:
     - <h2 class="govuk-heading-m"> What you can do </h2>
     - Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button"> Go the GOV.UK homepage </a>
-    - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link"> Contact the GOV.UK account team (opens in a new tab) </a>
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=passport-cri" class="govuk-link"> Contact the GOV.UK account team (opens in a new tab) </a>
 
 pageNotFound:
   title: Page not found
@@ -16,7 +16,7 @@ pageNotFound:
     - If you pasted the web address, check you copied the entire address.
     - You can also go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Go to the GOV.UK homepage</a>
-    - <a href="https://signin.account.gov.uk/contact-us" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=passport-cri" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
 
 sessionEnded:
   title: Session expired

--- a/test/browser/features/passport/Passport.feature
+++ b/test/browser/features/passport/Passport.feature
@@ -234,3 +234,11 @@ Feature: Passport Test
     Examples:
       | PassportSubject             | InvalidPassportNumber |
       | PassportSubjectHappyKenneth |                       |
+
+  @mock-api:passport-success
+  Scenario Outline: Check support links
+    And they click Footer <link> and assert I have been redirected correctly
+
+    Examples:
+      | link           |
+      | Support        |

--- a/test/browser/pages/PassportPage.js
+++ b/test/browser/pages/PassportPage.js
@@ -26,6 +26,9 @@ exports.PassportPage = class PlaywrightDevPage {
     this.passportValidToYear = this.page.locator(
       'xpath=//*[@id="expiryDate-year"]'
     );
+    this.supportLink = this.page.locator(
+      "xpath=/html/body/footer/div/div/div[1]/ul/li[5]/a"
+    );
 
     // Error summary items
 
@@ -387,6 +390,14 @@ exports.PassportPage = class PlaywrightDevPage {
     expect(await this.isCurrentPage()).to.be.true;
     await expect(await this.betaBannerReads.textContent()).to.contains(
       assertBetaBannerText
+    );
+  }
+
+  async assertFooterLink() {
+    await this.supportLink.click();
+    await this.page.waitForTimeout(2000); //waitForNavigation and waitForLoadState do not work in this case
+    expect(await this.page.title()).to.not.equal(
+      "Page not found - GOV.UK One Login"
     );
   }
 };

--- a/test/browser/step_definitions/PassportStepDefs.js
+++ b/test/browser/step_definitions/PassportStepDefs.js
@@ -1,6 +1,7 @@
 const { Given, When, Then } = require("@cucumber/cucumber");
 
 const { PassportPage } = require("../pages/PassportPage.js");
+const { expect } = require("chai");
 
 Then(/^I can see CTA {string}$/, async function () {});
 
@@ -365,5 +366,16 @@ Then(
   async function (errorSummaryMessage) {
     const passportPage = new PassportPage(this.page);
     await passportPage.assertYouWillBeAbleToFindSentence(errorSummaryMessage);
+  }
+);
+
+Given(
+  /^they click Footer (.*) and assert I have been redirected correctly$/,
+  async function (linkName) {
+    const passportPage = new PassportPage(this.page);
+
+    expect(passportPage.isCurrentPage()).to.be.true;
+
+    await passportPage.assertFooterLink(linkName);
   }
 );


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The support link has been changed to the new one-login version.

### Why did it change

Due to contact centre being onboarded to one-login.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-834](https://govukverify.atlassian.net/browse/LIME-834)

## Checklists

### Environment variables or secrets


[LIME-834]: https://govukverify.atlassian.net/browse/LIME-834?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ