### PR TITLE
LIME-868: Setting log level to request by default and debug for dev runs

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -73,6 +73,14 @@ Mappings:
     eu-west-2:
       AccountId: 652711504416
 
+  LogLevel:
+    Environment:
+      dev: "debug"
+      build: "debug"
+      staging: "request"
+      integration: "request"
+      production: "request"
+
 Resources:
   # Security Groups for the ECS service and load balancer
   LoadBalancerSG:
@@ -438,6 +446,8 @@ Resources:
                   "account.gov.uk",
                   !Sub "${Environment}.account.gov.uk",
                 ]
+            - Name: LOG_LEVEL
+              Value: !FindInMap [ LogLevel, Environment, !Ref 'Environment' ]
           PortMappings:
             - ContainerPort: 8080
               Protocol: tcp

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "node src/app.js",
     "start:ci": "NODE_ENV=development API_BASE_URL=http://localhost:8050/ yarn start",
-    "dev": "nodemon --inspect=0.0.0.0:9229 src/app.js",
+    "dev": "LOG_LEVEL=debug nodemon --inspect=0.0.0.0:9229 src/app.js",
     "build": "yarn build-sass && yarn build-js && yarn copy-assets",
     "build-sass": "rm -rf dist/public/style.css && sass --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed",
     "copy-assets": "mkdir -p dist && copyfiles -u 1 src/**/*.njk dist/ src/locales/**/** dist/ && copyfiles -u 3 src/assets/javascripts/*.js dist/public/scripts && copyfiles -u 3 src/assets/images/* dist/public/images",

--- a/src/app.js
+++ b/src/app.js
@@ -26,11 +26,13 @@ const {
   SESSION_SECRET,
   SESSION_TABLE_NAME,
   SESSION_TTL,
+  LOG_LEVEL,
 } = require("./lib/config");
 
 const { setup } = require("hmpo-app");
 
 const loggerConfig = {
+  consoleLevel: LOG_LEVEL,
   console: true,
   consoleJSON: true, // logstash json or pretty print output
   app: false,

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -23,6 +23,7 @@ module.exports = {
   SESSION_SECRET: process.env.SESSION_SECRET,
   SESSION_TABLE_NAME: process.env.SESSION_TABLE_NAME,
   SESSION_TTL: process.env.SESSION_TTL || 7200000, // two hours in ms
+  LOG_LEVEL: process.env.LOG_LEVEL || "request",
   REDIS: {
     SESSION_URL: process.env.REDIS_SESSION_URL,
     PORT: process.env.REDIS_PORT || 6379,


### PR DESCRIPTION
## Proposed changes

### What changed

Added config to set the log level to request and debug in the lower environments

### Why did it change

To ensure log levels are always correctly set in the higher environments for hmpo-app and common express

