### PR TITLE
LIME-784 DoB and Expiry only accept 4 digits

### DIFF
--- a/src/app/passport/controllers/details.js
+++ b/src/app/passport/controllers/details.js
@@ -3,7 +3,13 @@ const DateControllerMixin = require("hmpo-components").mixins.Date;
 
 const DateController = DateControllerMixin(BaseController);
 
+const logger = require("hmpo-logger").get();
+
 class PassportDetailsController extends DateController {
+  _padYear(value, offset) {
+    logger.info("offset value of {} ignored as no padding is applied", offset);
+    return value;
+  }
   async saveValues(req, res, callback) {
     super.saveValues(req, res, () => {
       req.sessionModel.set("showRetryMessage", false);

--- a/src/app/passport/controllers/details.test.js
+++ b/src/app/passport/controllers/details.test.js
@@ -34,4 +34,13 @@ describe("details controller", () => {
 
     expect(req.sessionModel.get("showRetryMessage")).to.equal(false);
   });
+
+  it("should not pad the year field", async () => {
+    var value = "30";
+    var offset = 0;
+
+    var finalYear = await details._padYear(value, offset);
+
+    expect(finalYear).to.equal("30");
+  });
 });

--- a/test/browser/features/passport/Passport.feature
+++ b/test/browser/features/passport/Passport.feature
@@ -166,19 +166,6 @@ Feature: Passport Test
       | PassportSubjectHappyKenneth | !@               | £$                 | %^ *              |
 
   @mock-api:passport-success @Passport_test @build @staging @integration
-  Scenario Outline: Passport Date of birth with 2 digits in the year field error validation
-    Given User enters passport data as a <PassportSubject>
-    And User re-enters day of birth as <InvalidDayOfBirth>
-    And User re-enters month of birth as <InvalidMonthOfBirth>
-    And User re-enters year of birth as <InvalidYearOfBirth>
-    When User clicks on continue
-    Then I see the date of birth error summary as Enter your date of birth as it appears on your passport
-    Then I see the date of birth error in the field as Enter your date of birth as it appears on your passport
-    Examples:
-      | PassportSubject             | InvalidDayOfBirth | InvalidMonthOfBirth | InvalidYearOfBirth |
-      | PassportSubjectHappyKenneth | 10                | 11                  | 57                 |
-
-  @mock-api:passport-success @Passport_test @build @staging @integration
   Scenario Outline: Passport Valid to date with special characters error validation
     Given User enters passport data as a <PassportSubject>
     And User re-enters expiry day as <InvalidExpiryDay>
@@ -203,19 +190,6 @@ Feature: Passport Test
     Examples:
       | PassportSubject             | InvalidExpiryDay | InvalidExpiryMonth | InvalidExpiryYear |
       | PassportSubjectHappyKenneth | 10               | 01                 | 2010              |
-
-  @mock-api:passport-success @Passport_test @build @staging @integration
-  Scenario Outline: Passport Valid to date with 2 digits in the year field error validation
-    Given User enters passport data as a <PassportSubject>
-    And User re-enters expiry day as <InvalidExpiryDay>
-    And User re-enters expiry month as <InvalidExpiryMonth>
-    And User re-enters expiry year as <InvalidExpiryYear>
-    When User clicks on continue
-    Then I see expiry date error summary as Enter the expiry date as it appears on your passport
-    And I see invalid expiry date in the field as Enter the expiry date as it appears on your passport
-    Examples:
-      | PassportSubject             | InvalidExpiryDay | InvalidExpiryMonth | InvalidExpiryYear |
-      | PassportSubjectHappyKenneth | 10               | 01                 | 10              |
 
   @mock-api:passport-success @Passport_test @build @staging @integration
   Scenario Outline: Passport - No date in the Valid to date field error validation

--- a/test/browser/features/passport/Passport.feature
+++ b/test/browser/features/passport/Passport.feature
@@ -166,6 +166,19 @@ Feature: Passport Test
       | PassportSubjectHappyKenneth | !@               | £$                 | %^ *              |
 
   @mock-api:passport-success @Passport_test @build @staging @integration
+  Scenario Outline: Passport Date of birth with 2 digits in the year field error validation
+    Given User enters passport data as a <PassportSubject>
+    And User re-enters day of birth as <InvalidDayOfBirth>
+    And User re-enters month of birth as <InvalidMonthOfBirth>
+    And User re-enters year of birth as <InvalidYearOfBirth>
+    When User clicks on continue
+    Then I see the date of birth error summary as Enter your date of birth as it appears on your passport
+    Then I see the date of birth error in the field as Enter your date of birth as it appears on your passport
+    Examples:
+      | PassportSubject             | InvalidDayOfBirth | InvalidMonthOfBirth | InvalidYearOfBirth |
+      | PassportSubjectHappyKenneth | 10                | 11                  | 57                 |
+
+  @mock-api:passport-success @Passport_test @build @staging @integration
   Scenario Outline: Passport Valid to date with special characters error validation
     Given User enters passport data as a <PassportSubject>
     And User re-enters expiry day as <InvalidExpiryDay>
@@ -190,6 +203,19 @@ Feature: Passport Test
     Examples:
       | PassportSubject             | InvalidExpiryDay | InvalidExpiryMonth | InvalidExpiryYear |
       | PassportSubjectHappyKenneth | 10               | 01                 | 2010              |
+
+  @mock-api:passport-success @Passport_test @build @staging @integration
+  Scenario Outline: Passport Valid to date with 2 digits in the year field error validation
+    Given User enters passport data as a <PassportSubject>
+    And User re-enters expiry day as <InvalidExpiryDay>
+    And User re-enters expiry month as <InvalidExpiryMonth>
+    And User re-enters expiry year as <InvalidExpiryYear>
+    When User clicks on continue
+    Then I see expiry date error summary as Enter the expiry date as it appears on your passport
+    And I see invalid expiry date in the field as Enter the expiry date as it appears on your passport
+    Examples:
+      | PassportSubject             | InvalidExpiryDay | InvalidExpiryMonth | InvalidExpiryYear |
+      | PassportSubjectHappyKenneth | 10               | 01                 | 10              |
 
   @mock-api:passport-success @Passport_test @build @staging @integration
   Scenario Outline: Passport - No date in the Valid to date field error validation

--- a/test/browser/features/passport/Passport.feature
+++ b/test/browser/features/passport/Passport.feature
@@ -88,6 +88,32 @@ Feature: Passport Test
       | PassportSubjectHappyKenneth | 51                | 71                  | 198                |
 
   @mock-api:passport-success @Passport_test @build @staging @integration
+  Scenario Outline: Passport Date of birth field failure as two digits provided
+    Given User enters passport data as a <PassportSubject>
+    And User re-enters day of birth as <validDayOfBirth>
+    And User re-enters month of birth as <validMonthOfBirth>
+    And User re-enters year of birth as <InvalidYearOfBirth>
+    When User clicks on continue
+    Then I see the date of birth error summary as Enter your date of birth as it appears on your passport
+    Then I see the date of birth error in the field as Enter your date of birth as it appears on your passport
+    Examples:
+      | PassportSubject             | validDayOfBirth | validMonthOfBirth | InvalidYearOfBirth |
+      | PassportSubjectHappyKenneth | 8                | 7                  | 65                |
+
+  @mock-api:passport-success @Passport_test @build @staging @integration
+  Scenario Outline: Passport Expiry Date field failure as two digits provided
+    Given User enters passport data as a <PassportSubject>
+    And User re-enters expiry day as <validDayOfExpiry>
+    And User re-enters expiry month as <validMonthOfExpiry>
+    And User re-enters expiry year as <InvalidYearOfExpiry>
+    When User clicks on continue
+    Then I see expiry date error summary as Enter the expiry date as it appears on your passport
+    And I see invalid expiry date in the field as Enter the expiry date as it appears on your passport
+    Examples:
+      | PassportSubject             | validDayOfExpiry | validMonthOfExpiry | InvalidYearOfExpiry |
+      | PassportSubjectHappyKenneth | 5                | 5                  | 25                |
+
+  @mock-api:passport-success @Passport_test @build @staging @integration
   Scenario Outline: Passport Date of birth with special characters error validation
     Given User enters passport data as a <PassportSubject>
     And User re-enters day of birth as <InvalidDayOfBirth>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

The functionality for dates has been changed so the passport webform will only accept a four digit year value. If someone tries to input two digits, they will be informed they should enter the value as it appears on their passport.

### Why did it change

This was changed due to a bug where users were allowed to enter a two digit expiry date but the logic was assuming it was '19' instead of '20' for the century.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-784](https://govukverify.atlassian.net/browse/LIME-784)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[LIME-784]: https://govukverify.atlassian.net/browse/LIME-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ