### PR TITLE
DFC-553: Upgrade analytics package to v1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build-sass": "rm -rf dist/public/stylesheets/application.css && sass --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed",
     "copy-assets": "mkdir -p dist/public/scripts && mkdir -p dist/public/images && mkdir -p dist/locales && cp -R src/locales/* dist/locales && cp -R src/assets/javascripts/*.js dist/public/scripts && cp -R src/assets/images/* dist/public/images",
     "build-js": "yarn build-js:analytics && yarn build-js:all",
-    "build-js:analytics": "mkdir -p dist/public/javascripts; uglifyjs node_modules/@govuk-one-login/one-login-analytics/lib/analytics.js node_modules/@govuk-one-login/di-ipv-cri-common-express/src/assets/javascript/analytics/ua/init.js -o dist/public/javascripts/analytics.js",
+    "build-js:analytics": "mkdir -p dist/public/javascripts; uglifyjs node_modules/@govuk-one-login/frontend-analytics/lib/analytics.js node_modules/@govuk-one-login/di-ipv-cri-common-express/src/assets/javascript/analytics/ua/init.js -o dist/public/javascripts/analytics.js",
     "build-js:all": "mkdir -p dist/public/javascripts; uglifyjs node_modules/govuk-frontend/govuk/all.js node_modules/hmpo-components/all.js --beautify -o dist/public/javascripts/all.js",
     "prepare": "husky install",
     "test": "SESSION_SECRET=1234 SESSION_TABLE_NAME=table-name mocha",
@@ -58,8 +58,8 @@
     "uglify-js": "latest"
   },
   "dependencies": {
-    "@govuk-one-login/di-ipv-cri-common-express": "6.2",
-    "@govuk-one-login/one-login-analytics": "^0.0.9",
+    "@govuk-one-login/di-ipv-cri-common-express": "6.2.2",
+    "@govuk-one-login/frontend-analytics": "^1.0.3",
     "@govuk-one-login/one-login-language-toggle": "^2.0.0",
     "aws-sdk": "^2.1300.0",
     "axios": "1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,10 +365,10 @@
   resolved "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz"
   integrity sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==
 
-"@govuk-one-login/di-ipv-cri-common-express@6.2":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-6.2.0.tgz#d1e50db124cedb56287d900886eb08deacea0b04"
-  integrity sha512-SsuFDzZOtaPvT/p/ItrDkDTrkCoREmlL1GL5r0jA5bn2DLwkvJ4Jfhf7YW1kiEVBtTK2kMcvO5M5Hdix1euNqQ==
+"@govuk-one-login/di-ipv-cri-common-express@6.2.2":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/di-ipv-cri-common-express/-/di-ipv-cri-common-express-6.2.2.tgz#0c154ebf94588f37e60c63d2b087fda0ed5403b1"
+  integrity sha512-Yar63UjB7bVHid1bhxNP9DzkT5OmploNPOW9qxavmbj/n0pjEQoW1TjWCSpK7DBoxcjwgCru4rYHJbGK1LXF7w==
   dependencies:
     hmpo-logger "7.0.1"
     i18next "23.8.1"
@@ -377,10 +377,10 @@
     lodash.differencewith "4.5.0"
     lodash.frompairs "4.0.1"
 
-"@govuk-one-login/one-login-analytics@^0.0.9":
-  version "0.0.9"
-  resolved "https://registry.npmjs.org/@govuk-one-login/one-login-analytics/-/one-login-analytics-0.0.9.tgz"
-  integrity sha512-zsvmvDgkvMZyO5OGHAyjj3aYlIToOLEbORwjCXOB9+1kqBTe0HfXqhzy6TMxHg00UctbX8yy8Gw1muFHoe2C9A==
+"@govuk-one-login/frontend-analytics@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-analytics/-/frontend-analytics-1.0.3.tgz#32da13a67f8804b96a648d53f21adf1b00ca3691"
+  integrity sha512-V0vH3OS5rz2Oj8IkOmKkl34FYA3liV8FaJzYVhVBn/hVjZD0cOaGhinunkdcgei2R9JJXiiU0JlEKDxPoYNdRQ==
 
 "@govuk-one-login/one-login-language-toggle@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
## Proposed changes

### What changed

Updates the analytics package version to latest
Updates common-express to the latest version

### Why did it change

The latest package release contains several bug fixes required by the analytics team to unblock their QA. The package has also been renamed to improve compliance.

This is the first major version push of the package, from this point forward dependabot should pick up new version releases.

Common-express has been upgraded as the analytics package is a peerDependency and has been renamed

## Tickets

[DFC-553](https://govukverify.atlassian.net/browse/DFC-553)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

[DFC-553]: https://govukverify.atlassian.net/browse/DFC-553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ