### PR TITLE
LIME-1140 Updating Github PR templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 <!-- Provide a general summary of your changes in the Title above -->
-<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->
+<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->
 
 ## Proposed changes
 
@@ -13,23 +13,9 @@
 
 ### Issue tracking
 <!-- List any related Jira tickets or GitHub issues -->
-<!-- List any related ADRs or RFCs -->
-<!-- Delete/copy as appropriate -->
 
-- [LIME-XXXX](https://govukverify.atlassian.net/browse/LIME-XXX)
-
-## Checklists
-
-### Environment variables or secrets
-
-<!-- Delete if changes DO include new environment variables or secrets -->
-- [ ] No environment variables or secrets were added or changed
-
-<!-- Delete if changes DO NOT include new environment variables or secrets -->
-- [ ] Documented in the [README](./blob/main/README.md)
-- [ ] Added to deployment repository
-- [ ] Added to local startup repository
+- [LIME-XXXX](https://govukverify.atlassian.net/browse/LIME-XXXX)
 
 ### Other considerations
 
-- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
+<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Updated Github PR templates, removing unused sections

### Why did it change

This was done off the back of a retro actions, as the PR templates were outdated and not being used effectively by team members

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1140](https://govukverify.atlassian.net/browse/LIME-1140)



[LIME-1140]: https://govukverify.atlassian.net/browse/LIME-1140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ