### PR TITLE
IPS-557: ecs canary stage 2 - deploy using nested stack

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -267,23 +267,23 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 609
+        "line_number": 617
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 610
+        "line_number": 618
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 612
+        "line_number": 620
       }
     ]
   },
-  "generated_at": "2024-08-13T09:57:42Z"
+  "generated_at": "2024-08-13T10:08:39Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -441,20 +441,28 @@ Resources:
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE
-      LoadBalancers:
-        - ContainerName: app
-          ContainerPort: 8080
-          TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
-      NetworkConfiguration:
-        AwsvpcConfiguration:
-          AssignPublicIp: DISABLED
-          SecurityGroups:
-            - !GetAtt ECSSecurityGroup.GroupId
-          Subnets:
-            - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
-            - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
-            - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
+      LoadBalancers: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - - ContainerName: app
+            ContainerPort: 8080
+            TargetGroupArn: !Ref LoadBalancerListenerTargetGroupECS
+      NetworkConfiguration: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - AwsvpcConfiguration:
+            AssignPublicIp: DISABLED
+            SecurityGroups:
+              - !GetAtt ECSSecurityGroup.GroupId
+            Subnets:
+              - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdA"
+              - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdB"
+              - Fn::ImportValue: !Sub "${VpcStackName}-PrivateSubnetIdC"
       TaskDefinition: !Ref ECSServiceTaskDefinition
+      TaskDefinition: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - !Ref ECSServiceTaskDefinition
       Tags:
         - Key: Name
           Value: !Sub "${AWS::StackName}-ECS"


### PR DESCRIPTION
## Proposed changes

### What changed
Stage 2 of 2 for enabling ECS Canaries (Stage 1 is [here](https://github.com/govuk-one-login/ipv-cri-uk-passport-front-v1/pull/152))

This is a fairly arbitrary change to trigger the deployment process, but removes some now-unused ECS config.

### Why did it change
Canary deployments provide extra safety measures when rolling out new application image versions

### Issue tracking
https://govukverify.atlassian.net/browse/IPS-557
