### PR TITLE
IPS-1118: Bau gha add lint on pre-merge and post-merge checks.

### DIFF
--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -26,7 +26,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: SAM Validate
-        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml --lint
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -24,11 +24,16 @@ jobs:
 
   run-premerge-checks:
     runs-on: ubuntu-latest
+    env:
+      AWS_REGION: eu-west-2
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: SAM Validate
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml --lint
 
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4

--- a/.github/workflows/secure-post-merge.yml
+++ b/.github/workflows/secure-post-merge.yml
@@ -26,7 +26,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: SAM Validate
-        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml
+        run: sam validate --region ${{ env.AWS_REGION }} -t deploy/template.yaml --lint
 
       # Likely source of node warning
       # https://github.com/aws-actions/amazon-ecr-login/issues/586

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,12 @@ repos:
         args: [ --allow-missing-credentials ]
     -   id: detect-private-key
 -   repo: https://github.com/awslabs/cfn-python-lint
-    rev: v1.5.0 # The version of cfn-lint to use
+    rev: v1.15.2 # The version of cfn-lint to use
     hooks:
     -   id: cfn-python-lint
         files: .template\.yaml$
 - repo: https://github.com/bridgecrewio/checkov.git
-  rev: '3.2.174'
+  rev: '3.2.256'
   hooks:
   - id: checkov
     verbose: true

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -267,23 +267,23 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 620
+        "line_number": 628
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 621
+        "line_number": 629
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 623
+        "line_number": 631
       }
     ]
   },
-  "generated_at": "2024-10-04T13:38:50Z"
+  "generated_at": "2024-10-18T08:56:25Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -173,6 +173,11 @@ Resources:
     Type:
       AWS::S3::Bucket
       #checkov:skip=CKV_AWS_18: This is the bucket where our access logs go and AWS advise not sending a bucket's access logs to itself.
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3045 # Using a legacy 'AccessControl: LogDeliveryWrite' setup for now
     Properties:
       BucketName: !Join
         - "-"
@@ -443,7 +448,10 @@ Resources:
         - !Ref "Environment"
         - desiredTaskCount
       EnableECSManagedTags: false
-      HealthCheckGracePeriodSeconds: 60
+      HealthCheckGracePeriodSeconds: !If
+        - UseCanaryDeployment
+        - !Ref AWS::NoValue
+        - 60
       LaunchType: FARGATE
       LoadBalancers: !If
         - UseCanaryDeployment


### PR DESCRIPTION
### What changed
- Add SAM validate on pre-merge checks and lint on the post merge checks

The following changes were required to pass the new linting steps:

1. Add metadata to ignore check `W3045 # Using a legacy 'AccessControl: LogDeliveryWrite'` setup for now
2. Create condition for `HealthCheckGracePeriodSeconds` (this Property is only used if canaries are disabled ie if the service is using a load balancer and not managed by CodeDeploy). This was to fix `E3056 | ECS service using HealthCheckGracePeriodSeconds must also have LoadBalancers specified` [E3056](https://github.com/aws-cloudformation/cfn-lint/blob/main/src/cfnlint/rules/resources/ecs/ServiceHealthCheckGracePeriodSeconds.py) See the docs at:
  - https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service_definition_parameters.html
  - https://govukverify.atlassian.net/wiki/spaces/PLAT/pages/3821732161/ECS+-+Canary+Deployments+Migration+Guidance

### Why did it change
- Taskdefinition duplication would have picked up if had a pre-merge checks.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1118](https://govukverify.atlassian.net/browse/LIME-1118)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1118]: https://govukverify.atlassian.net/browse/LIME-1118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ