### PR TITLE
LIME-1169 Set log group retention in days to 30 for all log groups

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -253,37 +253,37 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 65
+        "line_number": 69
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 105
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 616
+        "line_number": 620
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 617
+        "line_number": 621
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 619
+        "line_number": 623
       }
     ]
   },
-  "generated_at": "2024-09-19T14:46:53Z"
+  "generated_at": "2024-10-04T13:38:50Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -40,6 +40,10 @@ Parameters:
     Description: "Predefined deployment configuration for ECS application"
     Type: String
     Default: "None"
+  LogGroupRetentionInDays:
+    Description: "Retention for all log groups"
+    Type: Number
+    Default: "30"
 
 Conditions:
   IsNotDevelopment: !Or
@@ -478,7 +482,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/ecs/${AWS::StackName}-PassportFront-ECS
-      RetentionInDays: 14
+      RetentionInDays: !Ref LogGroupRetentionInDays
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   ECSAccessLogsGroupSubscriptionFilterCSLS:
@@ -759,7 +763,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-PassportFront-API-GW-AccessLogs
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
-      RetentionInDays: 14
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   APIGWAccessLogsGroupSubscriptionFilterCSLS:
     Type: AWS::Logs::SubscriptionFilter


### PR DESCRIPTION
## Proposed changes

### What changed

Ensure log groups are all set to 30 days retention

### Why did it change

To ensure log groups do not have extended retention lengths

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1169](https://govukverify.atlassian.net/browse/LIME-1169)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1169]: https://govukverify.atlassian.net/browse/LIME-1169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ