### PR TITLE
IPS-1284: Predictive scaling for ECS in forecast mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     -   id: check-json
     -   id: end-of-file-fixer
@@ -9,12 +9,12 @@ repos:
         args: [ --allow-missing-credentials ]
     -   id: detect-private-key
 -   repo: https://github.com/awslabs/cfn-python-lint
-    rev: v1.15.2 # The version of cfn-lint to use
+    rev: v1.22.3 # The version of cfn-lint to use
     hooks:
     -   id: cfn-python-lint
         files: .template\.yaml$
 - repo: https://github.com/bridgecrewio/checkov.git
-  rev: '3.2.256'
+  rev: '3.2.350'
   hooks:
   - id: checkov
     verbose: true

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -253,37 +253,37 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 69
+        "line_number": 66
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 106
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 622
+        "line_number": 629
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 623
+        "line_number": 630
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 625
+        "line_number": 632
       }
     ]
   },
-  "generated_at": "2024-10-22T15:39:02Z"
+  "generated_at": "2025-01-07T16:13:51Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -52,9 +52,6 @@ Conditions:
     - !Equals [!Ref Environment, integration]
     - !Equals [!Ref Environment, production]
   IsProduction: !Equals [!Ref Environment, production]
-  IsPerformance: !Or
-    - !Equals [!Ref Environment, build]
-    - !Equals [!Ref Environment, production]
   UsePermissionsBoundary: !Not
     - !Equals [!Ref PermissionsBoundary, "none"]
   UseCodeSigning: !Not
@@ -72,6 +69,8 @@ Mappings:
       ga4Disabled: "false"
       uaDisabled: "false"
       languageToggleDisabled: "false"
+      minECSCount: 1
+      maxECSCount: 4
     build:
       logLevel: "info"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -80,6 +79,8 @@ Mappings:
       ga4Disabled: "false"
       uaDisabled: "false"
       languageToggleDisabled: "false"
+      minECSCount: 4
+      maxECSCount: 60
     staging:
       logLevel: "warn"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -88,6 +89,8 @@ Mappings:
       ga4Disabled: "false"
       uaDisabled: "false"
       languageToggleDisabled: "false"
+      minECSCount: 2
+      maxECSCount: 4
     integration:
       logLevel: "warn"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -96,6 +99,8 @@ Mappings:
       ga4Disabled: "false"
       uaDisabled: "false"
       languageToggleDisabled: "false"
+      minECSCount: 2
+      maxECSCount: 4
     production:
       logLevel: "warn"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
@@ -104,6 +109,8 @@ Mappings:
       ga4Disabled: "false"
       uaDisabled: "false"
       languageToggleDisabled: "false"
+      minECSCount: 4
+      maxECSCount: 60
 
   # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:
@@ -824,22 +831,36 @@ Resources:
 
   # ECS Autoscaling
   ECSAutoScalingTarget:
-    Condition: IsPerformance
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
-      MinCapacity: 4
-      MaxCapacity: 60
-      ResourceId: !Join
-        - '/'
-        - - "service"
-          - !Ref PassportFrontEcsCluster
-          - !GetAtt PassportFrontEcsService.Name
+      MaxCapacity:
+        !FindInMap [EnvironmentConfiguration, !Ref Environment, maxECSCount]
+      MinCapacity:
+        !FindInMap [EnvironmentConfiguration, !Ref Environment, minECSCount]
+      ResourceId: !Sub service/${PassportFrontEcsCluster}/${PassportFrontEcsService.Name}
       RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/ecs.application-autoscaling.amazonaws.com/AWSServiceRoleForApplicationAutoScaling_ECSService"
       ScalableDimension: ecs:service:DesiredCount
       ServiceNamespace: ecs
 
+  ECSPredictiveScalingPolicy:
+    DependsOn: ECSAutoScalingTarget
+    Type: AWS::ApplicationAutoScaling::ScalingPolicy
+    Properties:
+      PolicyName: ECSPredictiveScalingPolicy
+      PolicyType: PredictiveScaling
+      ResourceId: !Sub service/${PassportFrontEcsCluster}/${PassportFrontEcsService.Name}
+      ScalableDimension: ecs:service:DesiredCount
+      ServiceNamespace: ecs
+      PredictiveScalingPolicyConfiguration:
+        MaxCapacityBreachBehavior: HonorMaxCapacity
+        MetricSpecifications:
+          - PredefinedMetricPairSpecification:
+              PredefinedMetricType: ECSServiceCPUUtilization
+            TargetValue: 60
+        Mode: ForecastOnly
+        SchedulingBufferTime: 600
+
   EcsStepScaleOutPolicy:
-    Condition: IsPerformance
     DependsOn: ECSAutoScalingTarget
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
@@ -881,7 +902,6 @@ Resources:
             # on Fargate, so leave the upper bound open
 
   EcsStepScaleInPolicy:
-    Condition: IsPerformance
     DependsOn: ECSAutoScalingTarget
     Type: AWS::ApplicationAutoScaling::ScalingPolicy
     Properties:
@@ -913,7 +933,6 @@ Resources:
             # with <20% utilisation
 
   EcsStepScaleOutAlarm:
-    Condition: IsPerformance
     DependsOn: ECSAutoScalingTarget
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -937,7 +956,6 @@ Resources:
       Threshold: "60"
 
   EcsStepScaleInAlarm:
-    Condition: IsPerformance
     DependsOn: ECSAutoScalingTarget
     Type: AWS::CloudWatch::Alarm
     Properties:


### PR DESCRIPTION
### What changed

- Added capacity mapping for ECS task counts 
- Removed condition on creating auto scaling policy so it applies to all envs
- This adds a new Predicitive scaling policy which will scale the number of instances based on some AWS created  algorithm using the previous traffic patterns as input. See this for more information:
https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-predictive-scaling.html
- The policy is in `Forecast Mode` only so we can understand its behaviour. The predictive scaling policy will not take any action, see below in dev:

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/d078d519-693e-4091-a46d-631566735cdd" />


### Why did it change

- Cost saving
- To be more Environmentally friendly
- Reliability for users

### Issue tracking
https://govukverify.atlassian.net/browse/IPS-1284
