### PR TITLE
LIME-1346 Capacity Management | Add 5xx critical alarm

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1066,12 +1066,14 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FE5XXErrorCriticalAlarm"
-      AlarmDescription: !Sub "There has been a significant proportion of 5XX errors on the frontend api-gateway. ${SupportManualURL}"
+      AlarmDescription: >
+        Trigger the 5xx cricical alarm if errorThreshold exceeds 80% with 10 or more invocations
+        and a minimum of 2 errors in 5 out of the last 5 minutes
       ActionsEnabled: true
       OKActions:
-        - !ImportValue platform-alarm-topic-critical-alert
+        - !Ref AlarmTopicPassport
       AlarmActions:
-        - !ImportValue platform-alarm-topic-critical-alert
+        - !Ref AlarmTopicPassport
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
       Threshold: 80
@@ -1086,22 +1088,22 @@ Resources:
           ReturnData: false
           MetricStat:
             Metric:
-              Namespace: AWS/ApiGateway
-              MetricName: Count
+              Namespace: AWS/ApplicationELB
+              MetricName: RequestCount
               Dimensions:
-                - Name: ApiId
-                  Value: !Ref ApiGwHttpEndpoint
+                - Name: LoadBalancer
+                  Value: !GetAtt LoadBalancer.LoadBalancerFullName
             Period: 60
             Stat: Sum
         - Id: error
           ReturnData: false
           MetricStat:
             Metric:
-              Namespace: AWS/ApiGateway
-              MetricName: 5XXError
+              Namespace: AWS/ApplicationELB
+              MetricName: HTTPCode_Target_5XX_Count
               Dimensions:
-                - Name: ApiId
-                  Value: !Ref ApiGwHttpEndpoint
+                - Name: LoadBalancer
+                  Value: !GetAtt LoadBalancer.LoadBalancerFullName
             Period: 60
             Stat: Sum
         - Id: errorPercentage

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -1062,6 +1062,53 @@ Resources:
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
+  FE5XXErrorCriticalAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-FE5XXErrorCriticalAlarm"
+      AlarmDescription: !Sub "There has been a significant proportion of 5XX errors on the frontend api-gateway. ${SupportManualURL}"
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue platform-alarm-topic-critical-alert
+      AlarmActions:
+        - !ImportValue platform-alarm-topic-critical-alert
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 2
+      Threshold: 80
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: errorThreshold
+          Label: errorThreshold
+          ReturnData: true
+          Expression: IF(invocations<10,0,errorPercentage)
+        - Id: invocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGwHttpEndpoint
+            Period: 60
+            Stat: Sum
+        - Id: error
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 5XXError
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGwHttpEndpoint
+            Period: 60
+            Stat: Sum
+        - Id: errorPercentage
+          Label: errorPercentage
+          ReturnData: false
+          Expression: (error/invocations)*100
+
   FrontTargetGroup5xxPercentErrors:
     Type: AWS::CloudWatch::Alarm
     Condition: UseCanaryDeployment


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

Ensure that there is a 5XX Alarm (P1) if more than 80% of traffic is returning 5XX in 2 of 5 datapoints.

### What changed

Added 5XX alarm to template.yaml

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1346](https://govukverify.atlassian.net/browse/LIME-1346)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1346]: https://govukverify.atlassian.net/browse/LIME-1346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ