### PR TITLE
LIME-1546 Upgrading FE Vital signs to log max EventLoopDelay

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@govuk-one-login/frontend-analytics": "2.0.1",
     "@govuk-one-login/frontend-language-toggle": "1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.1.1",
-    "@govuk-one-login/frontend-vital-signs": "0.1.1",
+    "@govuk-one-login/frontend-vital-signs": "0.1.3",
     "axe-playwright": "^2.0.3",
     "axios": "1.6.1",
     "cfenv": "1.2.4",


### PR DESCRIPTION
### What changed
Upgrading FE Vital signs to log max EventLoopDelay (fix brought in by latest patch version)