### PR TITLE
LIME-1641 Add Device Intelligence AC Tests to check for Cookie

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -41,7 +41,7 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: yarn install && yarn playwright install
+        run: yarn install
 
       - name: Build assets
         run: yarn build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-yarn lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-yarn test

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "node src/app.js",
-    "start:ci": "NODE_ENV=development API_BASE_URL=http://127.0.0.1:8050/ yarn start",
+    "start:ci": "DEVICE_INTELLIGENCE_ENABLED=true NODE_ENV=development API_BASE_URL=http://127.0.0.1:8050/ yarn start",
     "dev": "LOG_LEVEL=debug nodemon --inspect=0.0.0.0:9229 src/app.js",
     "build": "yarn build-sass && yarn build-js && yarn copy-assets",
     "build-sass": "rm -rf dist/public/stylesheets/application.css && sass --no-source-map src/assets/scss/application.scss dist/public/stylesheets/application.css --style compressed",

--- a/test/browser/features/passport/Passport.feature
+++ b/test/browser/features/passport/Passport.feature
@@ -309,3 +309,10 @@ Feature: Passport CRI - Happy Path and Field Valisation Tests
     And I assert the link on the error page is correct and live
     Then I go to page not found
     And I assert the link on the page not found page is correct and live
+
+  @mock-api:passport-success @Passport_test @build @staging @integration
+  Scenario: Driving Licence - Cookies - Device Intelligence
+    Given I see the Device Intelligence Cookie <DeviceIntelligenceCookieName>
+    Examples:
+      | DeviceIntelligenceCookieName |
+      | di-device-intelligence       |

--- a/test/browser/pages/PassportPage.js
+++ b/test/browser/pages/PassportPage.js
@@ -633,4 +633,34 @@ exports.PassportPage = class PlaywrightDevPage {
     expect(await this.isCurrentPage()).to.be.true;
     expect(await this.header.innerText()).to.equal(pageHeading);
   }
+
+  async checkDeviceIntelligenceCookie(deviceIntelligenceCookieName) {
+    // Wait for the page to fully load
+    await this.page.waitForLoadState("networkidle", { timeout: 5000 });
+
+    const cookies = await this.page.context().cookies();
+
+    const cookie = cookies.find(
+      (cookie) => cookie.name === deviceIntelligenceCookieName
+    );
+
+    if (!cookie) {
+      throw new Error(
+        `Cookie with name '${deviceIntelligenceCookieName}' not found.`
+      );
+    }
+
+    if (
+      cookie.value === undefined ||
+      cookie.value === null ||
+      cookie.value.trim() === ""
+    ) {
+      // Check for undefined, null, or empty string in value field of the cookie
+      throw new Error(
+        `Cookie with name '${deviceIntelligenceCookieName}' has no value.`
+      );
+    }
+
+    return true;
+  }
 };

--- a/test/browser/step_definitions/PassportStepDefs.js
+++ b/test/browser/step_definitions/PassportStepDefs.js
@@ -24,6 +24,16 @@ Then(
   }
 );
 
+Then(
+  /^I see the Device Intelligence Cookie (.*)$/,
+  async function (deviceIntelligenceCookieName) {
+    const passportPage = new PassportPage(this.page);
+    await passportPage.checkDeviceIntelligenceCookie(
+      deviceIntelligenceCookieName
+    );
+  }
+);
+
 Then(/^User clicks on continue$/, { timeout: 2 * 5000 }, async function () {
   const passportPage = new PassportPage(this.page);
   await passportPage.clickOnContinue();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3256,7 +3256,7 @@ execa@~8.0.1:
     signal-exit "^4.1.0"
     strip-final-newline "^3.0.0"
 
-express-async-errors@^3.1.1:
+express-async-errors@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/express-async-errors/-/express-async-errors-3.1.1.tgz#6053236d61d21ddef4892d6bd1d736889fc9da41"
   integrity sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==


### PR DESCRIPTION
Added new AC Test to check for device Intelligence cookie and that it has a value

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

New AC Test Added to fraud.feature
Removed Husky Folder as no longer used

### Why did it change

To check that the new device intelligence cookie has been loaded correctly after Fraud Check Page load

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1641](https://govukverify.atlassian.net/browse/LIME-1641)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1641]: https://govukverify.atlassian.net/browse/LIME-1641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ