### PR TITLE
LIME-1671 Set Cookie domain for all environments

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -267,23 +267,23 @@
         "filename": "deploy/template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 670
+        "line_number": 672
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 671
+        "line_number": 673
       },
       {
         "type": "Secret Keyword",
         "filename": "deploy/template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 673
+        "line_number": 675
       }
     ]
   },
-  "generated_at": "2025-05-15T13:43:44Z"
+  "generated_at": "2025-05-22T09:56:44Z"
 }

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -556,6 +556,8 @@ Resources:
                   "account.gov.uk",
                   !Sub "${Environment}.account.gov.uk"
                 ]
+            - Name: DEVICE_INTELLIGENCE_DOMAIN
+              Value: "account.gov.uk"
             - Name: LOG_LEVEL
               Value: !FindInMap [ EnvironmentConfiguration, !Ref "Environment", logLevel ]
             - Name: DEVICE_INTELLIGENCE_ENABLED

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -32,7 +32,8 @@ module.exports = {
     LANGUAGE_TOGGLE_DISABLED: process.env.LANGUAGE_TOGGLE_DISABLED || "true",
     DEVICE_INTELLIGENCE_ENABLED:
       process.env.DEVICE_INTELLIGENCE_ENABLED || false,
-    DEVICE_INTELLIGENCE_DOMAIN: process.env.FRONTEND_DOMAIN || "localhost"
+    DEVICE_INTELLIGENCE_DOMAIN:
+      process.env.DEVICE_INTELLIGENCE_DOMAIN || "localhost"
   },
   PORT: process.env.PORT || 5050,
   SESSION_SECRET: process.env.SESSION_SECRET,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

Remove environment specific domain set for Device Intelligence.

### What changed

Set DEVICE_INTELLIGENCE_DOMAIN to "account.gov.uk"

### Why did it change

To fix an issue with the header size of the device intelligence cookie

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1671](https://govukverify.atlassian.net/browse/LIME-1671)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1671]: https://govukverify.atlassian.net/browse/LIME-1671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ