### PR TITLE
LIME-1711 amend privacy link URL to updated URL

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -44,7 +44,7 @@ govuk:
           text: "Cwcis"
         - href: "https://signin.account.gov.uk/terms-and-conditions"
           text: "Telerau ac amodau"
-        - href: "https://signin.account.gov.uk/privacy-notice"
+        - href: "https://www.gov.uk/government/publications/govuk-one-login-privacy-notice"
           text: "Hysbysiad preifatrwydd"
         - href: "https://home.account.gov.uk/contact-gov-uk-one-login"
           text: "Cymorth (agor mewn tab newydd)"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -44,7 +44,7 @@ govuk:
           text: "Cookies"
         - href: "https://signin.account.gov.uk/terms-and-conditions"
           text: "Terms and conditions"
-        - href: "https://signin.account.gov.uk/privacy-notice"
+        - href: "https://www.gov.uk/government/publications/govuk-one-login-privacy-notice"
           text: "Privacy notice"
         - href: "https://home.account.gov.uk/contact-gov-uk-one-login"
           text: "Support (opens in new tab)"

--- a/test/browser/pages/PassportPage.js
+++ b/test/browser/pages/PassportPage.js
@@ -579,7 +579,8 @@ exports.PassportPage = class PlaywrightDevPage {
       Accessibility: "https://signin.account.gov.uk/accessibility-statement",
       Cookies: "https://signin.account.gov.uk/cookies",
       TsAndCs: "https://signin.account.gov.uk/terms-and-conditions",
-      Privacy: "https://signin.account.gov.uk/privacy-notice",
+      Privacy:
+        "https://www.gov.uk/government/publications/govuk-one-login-privacy-notice",
       Support: "https://home.account.gov.uk/contact-gov-uk-one-login",
       OGL: "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
       CrownCopyright:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Gov.uk changed it's privacy notice URL from https://signin.account.gov.uk/privacy-notice to https://www.gov.uk/government/publications/govuk-one-login-privacy-notice. This PR amends the privacy notice URL to the updated version. 

This is being completed for Fraud, DL and Passport. 

Evidence in ticket. 

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1711](https://govukverify.atlassian.net/browse/LIME-1711)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1711]: https://govukverify.atlassian.net/browse/LIME-1711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ