### PR TITLE
LIME-1886 - Updated the pre-merge-workflow to use cucumber reporting

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -61,3 +61,29 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Get test results history
+        uses: actions/checkout@v4
+        if: always()
+        continue-on-error: true
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Cucumber HTML Report action
+        uses: PavanMudigonda/html-reporter-github-pages@v1.1
+        id: test-report
+        if: always()
+        with:
+          test_results: reports
+          gh_pages: gh-pages
+          results_history: results-history
+
+      - name: Publish Github Pages
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        uses: peaceiris/actions-gh-pages@v3.9.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: results-history
+          keep_files: true


### PR DESCRIPTION
…steps

The cucumber reporting steps have been missing from the Passport Front Repo Added the steps into the pre-merge-workflow to align with how the Fraud pre-merge-workflow is configured


### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1886](https://govukverify.atlassian.net/browse/LIME-1886)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
